### PR TITLE
Multiple start splash players

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -104,6 +104,8 @@ extend(flowplayer, {
       hlsQualities: true,
 
       splash: false,
+       
+      splashUnload: true,
 
       live: false,
       livePositionOffset: 120,
@@ -591,7 +593,7 @@ function initializePlayer(element, opts, callback) {
                 var playerId = el.getAttribute('data-flowplayer-instance-id');
                 if (playerId === root.getAttribute('data-flowplayer-instance-id')) return;
                 var a = instances[Number(playerId)];
-                if (a && a.conf.splash) a.unload();
+                if (a && a.conf.splash && a.conf.splashUnload) a.unload();
               });
 
             }


### PR DESCRIPTION
I have a page for video surveillance with a lot of cameras and I need to watch video from two or more cameras at the same time.
The splash mode allows you to reduce the load on the browser while the page loads, but it does not allow you to start the playback at the same time.

I prepared a patch for the ability to configure this behavior. Now for each player you can configure the behavior: unload at the play of another player or not.